### PR TITLE
fix: handle offset below zero

### DIFF
--- a/samples/read-file.c
+++ b/samples/read-file.c
@@ -359,9 +359,10 @@ static int goto_file(struct ccli *ccli, const char *command,
 		offset += rf->pos;
 		break;
 	case GOTO_BACKWARD:
-		offset = rf->pos - offset;
-		if (offset < 0)
+		if (offset > rf->pos)
 			offset = 0;
+		else
+			offset = rf->pos - offset;
 		break;
 	}
 


### PR DESCRIPTION
"offset" is size_t, so the check offset < 0 is invalid

Currently it's not actually causing a problem, but the error message is incorrect:

```
$ ./bin/read-file bin/read-file 
Reading file bin/read-file
rfile> goto -8  
Size fffffffffffffff8 (-8) is greater than the size of the file (50832)
rfile> dump 32  
0000000000000000: 7f 45 4c 46 02 01 01 00  00 00 00 00 00 00 00 00  |.ELF............|
0000000000000010: 03 00 3e 00 01 00 00 00  60 14 00 00 00 00 00 00  |..>.....`.......|
```