### PR TITLE
[PATCH v3 0/3] Cleanup and fix potential undefined behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 *.d
 *.so
 libccli.pc
+*.patch

--- a/src/ccli.c
+++ b/src/ccli.c
@@ -206,7 +206,7 @@ static int line_parse(struct line_buf *line, char ***pargv)
 	while (*p) {
 		bool last = false;
 
-		while (isspace(*p))
+		while (isspace((unsigned char)*p))
 			p++;
 
 		if (!*p)
@@ -233,7 +233,7 @@ static int line_parse(struct line_buf *line, char ***pargv)
 			default:
 				if (q)
 					break;
-				if (isspace(*p))
+				if (isspace((unsigned char)*p))
 					last = true;
 				break;
 			}
@@ -605,7 +605,7 @@ static void word_completion(struct ccli *ccli, struct line_buf *line, int tab)
 	word = argc - 1;
 
 	/* If the cursor is on a space, there's no word to match */
-	if (isspace(copy.line[copy.pos - 1])) {
+	if (isspace((unsigned char)copy.line[copy.pos - 1])) {
 		match = "";
 		word++;
 	} else {
@@ -664,12 +664,12 @@ static void do_completion(struct ccli *ccli, struct line_buf *line, int tab)
 	int match = -1;
 
 	/* Completion currently only works with the first word */
-	while (i >= 0 && !isspace(line->line[i]))
+	while (i >= 0 && !isspace((unsigned char)line->line[i]))
 		i--;
 
 	s = i + 1;
 
-	while (i >= 0 && isspace(line->line[i]))
+	while (i >= 0 && isspace((unsigned char)line->line[i]))
 		i--;
 
 	/* If the pos was at the first word, i will be less than zero */

--- a/src/ccli.c
+++ b/src/ccli.c
@@ -56,7 +56,7 @@ static void cleanup(void)
 {
 	tcsetattr(STDIN_FILENO, TCSANOW, &savein);
 	tcsetattr(STDOUT_FILENO, TCSANOW, &saveout);
-};
+}
 
 static void echo(struct ccli *ccli, char ch)
 {


### PR DESCRIPTION
```
From 5610478a9fc8653231a7c1b7e4b66d0f6aef98ac Mon Sep 17 00:00:00 2001
From: Ammar Faizi <ammarfaizi2@gnuweeb.org>
Date: Mon, 17 Jan 2022 00:43:45 +0700
Subject: [PATCH v3 0/3] Cleanup and fix potential undefined behavior

Hi Steven,

There are 3 patches in this series.

  - PATCH 1/3 is just a trivial cleanup.
  - PATCH 2/3 adds *.patch file to .gitignore.
  - PATCH 3/3 fixes potential undefined behavior of ctype functions.

Please review...

v3:
  - Commit message in patch 2/3 used ".gitignore:" as a prefix,
    change it to "ccli:".

v2:
  - Fix commit message in patch 3/3.

Link v2: https://github.com/rostedt/libccli/pull/3
Link v1: https://github.com/rostedt/libccli/pull/2

---
Ammar Faizi (3):
  ccli: Remove unused semicolon
  ccli: Add `*.patch` file to .gitignore
  ccli: Cast argument of ctype functions to unsigned char

 .gitignore |  1 +
 src/ccli.c | 12 ++++++------
 2 files changed, 7 insertions(+), 6 deletions(-)


base-commit: 37bfea9cfb117bcb2a408e23b0ab2fab1c043509
-- 
2.32.0
```