### PR TITLE
[PATCH v4 0/3] Cleanup and fix potential undefined behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 *.d
 *.so
 libccli.pc
+*.patch

--- a/src/ccli-local.h
+++ b/src/ccli-local.h
@@ -13,6 +13,8 @@
 
 #define __hidden __attribute__((visibility ("hidden")))
 
+#define ISSPACE(c) isspace((unsigned char)(c))
+
 struct line_buf {
 	char *line;
 	int size;

--- a/src/ccli.c
+++ b/src/ccli.c
@@ -441,7 +441,7 @@ static void word_completion(struct ccli *ccli, struct line_buf *line, int tab)
 	word = argc - 1;
 
 	/* If the cursor is on a space, there's no word to match */
-	if (isspace(copy.line[copy.pos - 1])) {
+	if (ISSPACE(copy.line[copy.pos - 1])) {
 		match = "";
 		word++;
 	} else {
@@ -506,12 +506,12 @@ static void do_completion(struct ccli *ccli, struct line_buf *line, int tab)
 	int match = -1;
 
 	/* Completion currently only works with the first word */
-	while (i >= 0 && !isspace(line->line[i]))
+	while (i >= 0 && !ISSPACE(line->line[i]))
 		i--;
 
 	s = i + 1;
 
-	while (i >= 0 && isspace(line->line[i]))
+	while (i >= 0 && ISSPACE(line->line[i]))
 		i--;
 
 	/* If the pos was at the first word, i will be less than zero */

--- a/src/ccli.c
+++ b/src/ccli.c
@@ -49,7 +49,7 @@ static void cleanup(void)
 {
 	tcsetattr(STDIN_FILENO, TCSANOW, &savein);
 	tcsetattr(STDOUT_FILENO, TCSANOW, &saveout);
-};
+}
 
 static void echo(struct ccli *ccli, char ch)
 {

--- a/src/line.c
+++ b/src/line.c
@@ -152,7 +152,7 @@ int ccli_line_parse(const char *line, char ***pargv)
 	while (*p) {
 		bool last = false;
 
-		while (isspace(*p))
+		while (ISSPACE(*p))
 			p++;
 
 		if (!*p)
@@ -179,7 +179,7 @@ int ccli_line_parse(const char *line, char ***pargv)
 			default:
 				if (q)
 					break;
-				if (isspace(*p))
+				if (ISSPACE(*p))
 					last = true;
 				break;
 			}


### PR DESCRIPTION
```
From 45fdfda84d799d2bd62cec62ba0a4c1fd684fa4e Mon Sep 17 00:00:00 2001
From: Ammar Faizi <ammarfaizi2@gnuweeb.org>
Date: Mon, 17 Jan 2022 05:08:03 +0700
Subject: [PATCH v4 0/3] Cleanup and fix potential undefined behavior

Hi Steven,

There are 3 patches in this series.

  - PATCH 1/3 is just a trivial cleanup.
  - PATCH 2/3 adds *.patch file to .gitignore.
  - PATCH 3/3 fixes potential undefined behavior of ctype functions.

Please review...

v4:
  - Addressed comment to add a new macro ISSPACE() instead of
    having `(unsigned char)` cast all over the place.

v3:
  - Commit message in patch 2/3 used ".gitignore:" as a prefix,
    change it to "ccli:".

v2:
  - Fix commit message in patch 3/3.

Link v3: https://github.com/rostedt/libccli/pull/4
Link v2: https://github.com/rostedt/libccli/pull/3
Link v1: https://github.com/rostedt/libccli/pull/2

---
Ammar Faizi (3):
  ccli: Add `*.patch` file to .gitignore
  ccli: Remove unused semicolon
  ccli: Add a new macro ISSPACE() and replace isspace() calls with it

 .gitignore       | 1 +
 src/ccli-local.h | 2 ++
 src/ccli.c       | 8 ++++----
 src/line.c       | 4 ++--
 4 files changed, 9 insertions(+), 6 deletions(-)


base-commit: 294f8b5064253190ed44ca245edb0abf3a0dcbe9
-- 
2.32.0
```