### PR TITLE
[RFC] ccli: Enable execute more than one command at the same line

### DIFF
--- a/include/ccli.h
+++ b/include/ccli.h
@@ -9,6 +9,11 @@
 
 struct ccli;
 
+struct command_args {
+	char **argv;
+	int argc;
+};
+
 typedef int (*ccli_command_callback)(struct ccli *ccli, const char *command,
 				     const char *line, void *data,
 				     int argc, char **argv);
@@ -37,7 +42,7 @@ int ccli_register_unknown(struct ccli *ccli, ccli_command_callback callback,
 			  void *data);
 
 
-int ccli_line_parse(const char *line, char ***argv);
+int ccli_line_parse(const char *line, struct command_args **pcmd_args);
 void ccli_argv_free(char **argv);
 
 const char *ccli_history(struct ccli *ccli, int past);

--- a/src/ccli-local.h
+++ b/src/ccli-local.h
@@ -31,7 +31,7 @@ extern void line_left(struct line_buf *line);
 extern void line_backspace(struct line_buf *line);
 extern void line_del(struct line_buf *line);
 extern int line_copy(struct line_buf *dst, struct line_buf *src, int len);
-extern int line_parse(struct line_buf *line, char ***pargv);
+extern int line_parse(struct line_buf *line, struct command_args **pcmd_args);
 extern void line_replace(struct line_buf *line, char *str);
 
 extern void free_argv(int argc, char **argv);


### PR DESCRIPTION
Hi,

This PR is just to get feedback from you, supposing you would implement/allow
this functionality.
This PR enables, eg:
`goto 2 && dump 32 && read string`

I'm not a C developer, so there are probably lots of room for improvement.

One current problem of this approach is that `&&` might be an argument
to some command.
Maybe one way to handle that is to check if the next word is a command or not.
