### PR TITLE
Clarify the need of CUnit-devel pkg for developers

### DIFF
--- a/README
+++ b/README
@@ -205,3 +205,7 @@ Goodbye!
 
 This gives you a command line interface to browse a binary file and walk through
 its contents.
+
+Requirements to build tests:
+
+	* CUnit-devel

--- a/README
+++ b/README
@@ -208,4 +208,6 @@ its contents.
 
 Requirements to build tests:
 
-	* CUnit-devel
+	* CUnit-devel (CentOS)
+	* libcunit1-dev (Ubuntu/Debian)
+	* cunit-devel (OpenSUSE)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-This is a very simple shell like interface for CLI activities.
+# This is a very simple shell like interface for CLI activities.
 
 More will be added to this, but for now, this is the basic
 idea:
 
+```
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -119,23 +120,29 @@ int main(int argc, char **argv)
 
 	return 0;
 }
+```
 
-To build:
+## To build:
 
+```
   make
+```
+## To build the sample file(s)
 
-To build the sample file(s)
-
+```
   make samples
+```
 
 The samples will be placed in a local bin directory. One that you may find
 useful is the read-file sample.
 
+```
  bin/read-file binary-file
+```
 
 This will give you a command line interface that can read the binary file:
 
-
+```
 -----------------------------------------------------------------------------
  $ bin/read-file trace.dat
 Reading file /tmp/trace.dat
@@ -202,11 +209,12 @@ rfile> help
 rfile> quit
 Goodbye!
 -----------------------------------------------------------------------------
+```
 
 This gives you a command line interface to browse a binary file and walk through
 its contents.
 
-Requirements to build tests:
+## Requirements to build tests:
 
 	* CUnit-devel (CentOS)
 	* libcunit1-dev (Ubuntu/Debian)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# This is a very simple shell like interface for CLI activities.
+# LIBCCLI
+
+This is a very simple shell like interface for CLI activities.
 
 More will be added to this, but for now, this is the basic
 idea:


### PR DESCRIPTION
Developers must install the CUnit-devel package that contains the header files
and libraries for use with CUnit package. Otherwise the make test command will
not work

Signed-off-by: VictorRodriguez <victor.rodriguez.bahena@intel.com>